### PR TITLE
README: add Demo section with inline video

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ An open alternative to ElevenLabs conversational agents and Gemini Live.
 <img src="assets/hero.png" alt="OpenLive in a live call — the voice orb listening, with a live transcript" width="820" />
 </div>
 
+## Demo
+
+https://github.com/user-attachments/assets/6ebe0e47-44cb-4d4f-bc33-7f15651e6342
+
 ---
 
 ## What this is


### PR DESCRIPTION
Adds a `## Demo` section under the hero with the uploaded demo video.

Uses the bare `user-attachments` URL on its own line — GitHub's supported way to render an inline video player in a README (HTML `<video>` tags get sanitized out; committed repo files don't get a player).

🤖 Generated with [Claude Code](https://claude.com/claude-code)