### PR TITLE
Add 12+ model providers and optional separate vision model

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,9 +89,12 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      # Give users a clean release: a short body pointing at the two installers,
-      # and strip the *.blockmap noise. The *.yml + mac *.zip stay — auto-update
-      # (electron-updater) needs them; users just follow the download table.
+      # Need the repo checked out to read CHANGELOG.md for the release highlights.
+      - uses: actions/checkout@v4
+
+      # Give users a clean release: this version's CHANGELOG highlights, a download
+      # table pointing at the two installers, and strip the *.blockmap noise. The
+      # *.yml + mac *.zip stay — auto-update (electron-updater) needs them.
       - name: Publish the release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -99,6 +102,12 @@ jobs:
           REPO: ${{ github.repository }}
         run: |
           BASE="https://github.com/$REPO/releases/download/$TAG"
+          # Best-effort: pull this tag's section out of CHANGELOG.md. Empty if the
+          # file or section is missing — the release still publishes with the table.
+          HIGHLIGHTS=""
+          if [ -f CHANGELOG.md ]; then
+            HIGHLIGHTS=$(awk -v v="${TAG#v}" 'index($0,"## ["v"]")==1{f=1;print;next} f&&/^## \[/{exit} f&&/^\[.*\]: /{exit} f{print}' CHANGELOG.md || true)
+          fi
           NOTES="## Download OpenLive ${TAG}
 
           | Platform | Download |
@@ -108,6 +117,12 @@ jobs:
 
           On first launch macOS may take a few seconds to verify the app — that's normal.
           "
+          if [ -n "$HIGHLIGHTS" ]; then
+            NOTES="${NOTES}
+          ---
+
+          ${HIGHLIGHTS}"
+          fi
           gh release edit "$TAG" --repo "$REPO" --draft=false --latest --notes "$NOTES"
           for a in $(gh release view "$TAG" --repo "$REPO" --json assets -q '.assets[].name' | grep -E '\.blockmap$'); do
             gh release delete-asset "$TAG" "$a" --yes --repo "$REPO" || true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,28 @@
+# Changelog
+
+All notable changes to OpenLive are recorded here. The newest version is on top.
+Releases before 0.1.9 predate this file — see the
+[GitHub releases](https://github.com/katipally/openlive/releases) for those.
+
+## [0.1.9] - 2026-07-11
+
+### Added
+- **A dozen more model providers.** Alongside Anthropic, OpenAI, and MiniMax,
+  OpenLive now speaks to Google Gemini, xAI Grok, DeepSeek, Mistral, Groq, Cerebras,
+  Together, Fireworks, OpenRouter, Perplexity, and Ollama (local and cloud). Paste a
+  key and the model list loads live from the provider — nothing hardcoded.
+- **Separate vision model (optional).** If your live model can't see, point OpenLive
+  at a dedicated vision model under Settings → Vision model. Camera and screen frames
+  are described by that model and handed to your live model, so a fast text-only
+  model can still watch your screen. Leave it off and the live model sees for itself.
+- **Real vision capability in the picker.** The `vision` badge now comes from actual
+  provider / models.dev metadata rather than a name guess, and the picker warns when
+  the selected model can't accept images.
+
+### Changed
+- A third wire adapter (OpenAI Chat Completions) joins the Anthropic and OpenAI
+  Responses adapters, so most hosted providers work through one code path.
+- Snapshot model defaults refreshed to current IDs (e.g. DeepSeek V4, Grok 4.5),
+  preferring fast vision-capable models for the voice + camera loop.
+
+[0.1.9]: https://github.com/katipally/openlive/releases/tag/v0.1.9

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ pnpm desktop:build:win # build the Windows installer (run on Windows)
 apps/desktop     Electron shell: local servers, permissions, window, auto-update
 apps/web         Next.js UI + the on-device voice engine in src/lib/live
 services/agent   the /live WebSocket and the model tools
-packages/harness model adapters (Anthropic, OpenAI, MiniMax), model listing
+packages/harness model adapters (Anthropic / OpenAI Responses / OpenAI Chat), model listing
 packages/shared  the wire protocol and shared types
 packages/db      JSON-file store for keys, settings, conversations
 ```

--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ OpenLive is that plumbing, built and open. It connects any chat model to real-ti
 voice and vision, and the whole voice loop runs on-device. The desktop app is the
 reference build: download it, paste a key for the model you want, and talk.
 
-You bring the brain (Anthropic, OpenAI, or MiniMax today, more to come). OpenLive
-gives it ears, a mouth, and eyes.
+You bring the brain — Anthropic, OpenAI, Google, xAI, DeepSeek, Groq, Ollama, and a
+dozen more. OpenLive gives it ears, a mouth, and eyes.
 
 ## Features
 
@@ -49,12 +49,15 @@ gives it ears, a mouth, and eyes.
   run in the app on WebGPU. Nothing you say leaves the machine.
 - **It can see.** Turn on your camera or share your screen and the model watches it
   live, like a video call. The `look` tool grabs a crisp hi-res frame when it needs
-  to read a label or a line of code.
-- **Bring your own model.** Anthropic, OpenAI, and MiniMax today. Models are fetched
-  live from the provider with vision / reasoning / context / price surfaced in the
-  picker, and reasoning effort is a dial from Auto to Max. It's a layer, not a walled
-  app — fork it to wire up other providers, your own agent backend, a self-hosted
-  endpoint, or a local model.
+  to read a label or a line of code. Running a text-only model? Point OpenLive at a
+  separate vision model and it does the seeing while your main model does the talking.
+- **Bring your own model.** Over a dozen providers out of the box — Anthropic,
+  OpenAI, Google Gemini, xAI Grok, DeepSeek, Mistral, MiniMax, the fast-inference
+  hosts (Groq, Cerebras, Together, Fireworks), OpenRouter, Perplexity, and Ollama
+  (local or cloud). Models are fetched live from each provider with vision / reasoning
+  / context / price surfaced in the picker, and reasoning effort is a dial from Auto
+  to Max. It's a layer, not a walled app — fork it to wire up your own agent backend
+  or a self-hosted endpoint.
 - **Agent tools.** Web search, fetch a URL, remember a fact across calls, and a live
   checklist — plus, in the desktop app, read/write your clipboard and open a URL.
 - **Barge-in.** Interrupt any time and it stops mid-word, like a real conversation.

--- a/apps/web/src/app/api/models/route.ts
+++ b/apps/web/src/app/api/models/route.ts
@@ -32,6 +32,7 @@ export async function GET(req: Request) {
         contextWindow: m.contextWindow,
         maxOutput: m.maxOutput,
         reasoning: m.reasoning,
+        vision: m.vision,
         cost: m.cost,
       })),
     );

--- a/apps/web/src/app/api/settings/route.ts
+++ b/apps/web/src/app/api/settings/route.ts
@@ -7,7 +7,7 @@ export const dynamic = "force-dynamic";
 // Provider + model are chosen live in Settings; nothing hardcoded. Live effort
 // defaults to "auto" (lowest the model supports → smoothest voice).
 const DEFAULTS = { liveEffort: "auto" };
-const KEYS = ["liveModel", "liveProviderId", "liveEffort"];
+const KEYS = ["liveModel", "liveProviderId", "liveEffort", "visionProviderId", "visionModel"];
 
 export function GET() {
   return NextResponse.json({ ...DEFAULTS, ...getAllSettings() });

--- a/apps/web/src/components/live/ModelQuickPick.tsx
+++ b/apps/web/src/components/live/ModelQuickPick.tsx
@@ -28,6 +28,9 @@ export function ModelQuickPick({ onOpenSettings }: { onOpenSettings: () => void 
   });
 
   const effort = settings?.liveEffort ?? "auto";
+  // Warn only on KNOWN-blind models (real metadata) with no vision model set.
+  const model = models.find((m) => m.id === settings?.liveModel);
+  const blind = model?.vision === false && !settings?.visionModel;
 
   return (
     <div className="flex w-full max-w-xs flex-col gap-2 rounded-xl border border-border bg-surface/60 p-2.5">
@@ -46,7 +49,9 @@ export function ModelQuickPick({ onOpenSettings }: { onOpenSettings: () => void 
       </div>
       <div className="flex items-center justify-between px-0.5 text-[11px] text-faint">
         <span>Effort: <span className="capitalize text-muted-foreground">{effort}</span></span>
-        {!hasKey && <span className="inline-flex items-center gap-1 text-arc"><AlertCircle className="size-3" /> no API key yet</span>}
+        {!hasKey
+          ? <span className="inline-flex items-center gap-1 text-arc"><AlertCircle className="size-3" /> no API key yet</span>
+          : blind ? <span className="inline-flex items-center gap-1 text-arc"><AlertCircle className="size-3" /> can’t see — set a vision model</span> : null}
       </div>
     </div>
   );

--- a/apps/web/src/components/settings/ModelsSettings.tsx
+++ b/apps/web/src/components/settings/ModelsSettings.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { KeyRound, Check, Trash2, Eye, Brain, Zap } from "lucide-react";
+import { KeyRound, Check, Trash2, Eye, EyeOff, Brain, Zap, AlertTriangle, ChevronDown } from "lucide-react";
 // Pure subpaths only — the barrel pulls in catalog/models (node:fs), which can't
 // bundle into this client component.
 import { BUILTIN_PROVIDERS } from "@openlive/harness/registry";
@@ -13,6 +13,10 @@ import { SearchSelect, type SearchOption } from "./SearchSelect";
 import { cn } from "@/lib/cn";
 
 const fmtCtx = (n?: number) => (n ? (n >= 1_000_000 ? `${n / 1_000_000}M` : `${Math.round(n / 1000)}k`) : "—");
+
+// Real image-input capability when the API reports it (models.dev / provider
+// payload); fall back to the name heuristic when it doesn't.
+const hasVision = (providerId: string, m: ModelInfo) => m.vision ?? modelVision(providerId, m.id);
 
 // Every provider the harness supports. `protocol` drives which reasoning efforts
 // a model can take.
@@ -70,7 +74,7 @@ function ProviderKey({ kind }: { kind: string }) {
 
 function ModelBadges({ providerId, m }: { providerId: string; m?: ModelInfo }) {
   if (!m) return null;
-  const vision = modelVision(providerId, m.id);
+  const vision = hasVision(providerId, m);
   return (
     <div className="mt-2.5 flex flex-wrap items-center gap-x-3 gap-y-1 text-[11.5px] text-muted-foreground">
       {vision && <span className="inline-flex items-center gap-1 text-foreground"><Eye className="size-3.5" /> vision</span>}
@@ -81,6 +85,44 @@ function ModelBadges({ providerId, m }: { providerId: string; m?: ModelInfo }) {
       {m.maxOutput ? <span>Max out <b className="text-foreground">{Math.round(m.maxOutput / 1000)}k</b></span> : null}
       {m.cost ? <span>${m.cost.input}/M in</span> : null}
       {m.cost ? <span>${m.cost.output}/M out</span> : null}
+    </div>
+  );
+}
+
+// Optional dedicated vision model, its own provider. Used only when the live
+// model can't see: frames are described by this model and handed to the live one.
+function VisionModelPicker() {
+  const qc = useQueryClient();
+  const { data: providers = [] } = useQuery({ queryKey: ["providers"], queryFn: api.providers });
+  const { data: settings } = useQuery({ queryKey: ["settings"], queryFn: api.settings });
+  const save = useMutation({
+    mutationFn: (b: Record<string, string>) => api.updateSettings(b),
+    onSuccess: (s) => qc.setQueryData(["settings"], s),
+  });
+
+  // Default the provider box to a keyed provider so the model list isn't empty.
+  const vProvider = settings?.visionProviderId
+    ?? providers.find((p) => p.isDefault)?.kind ?? providers[0]?.kind ?? PROVIDERS[0]!.id;
+  const { data: models = [] } = useQuery({ queryKey: ["models", vProvider], queryFn: () => api.models(vProvider), enabled: !!vProvider });
+
+  // Only vision-capable models make sense here.
+  const options: SearchOption[] = models
+    .filter((m) => hasVision(vProvider, m))
+    .map((m) => ({ value: m.id, label: m.display_name, hint: m.reasoning ? "reasoning" : "fast" }));
+
+  return (
+    <div className="flex flex-col gap-2.5">
+      <select value={vProvider} aria-label="Vision provider"
+        onChange={(e) => save.mutate({ visionProviderId: e.target.value, visionModel: "" })}
+        className="h-9 w-full rounded-lg border border-border bg-card px-3 text-[12.5px] text-foreground outline-none focus:border-border-heavy">
+        {PROVIDERS.map((p) => <option key={p.id} value={p.id}>{p.name}</option>)}
+      </select>
+      <SearchSelect value={settings?.visionModel ?? ""} onChange={(id) => save.mutate({ visionModel: id })}
+        options={options} placeholder={models.length ? "None — use the live model to see" : "Add a key to load models…"}
+        disabled={!models.length} emptyText="No vision models here" />
+      {settings?.visionModel
+        ? <button onClick={() => save.mutate({ visionModel: "" })} className="self-start text-[11.5px] text-muted-foreground hover:text-foreground">Clear — let the live model see</button>
+        : null}
     </div>
   );
 }
@@ -104,9 +146,13 @@ export function ModelsSettings() {
   const effort = settings?.liveEffort ?? "auto";
 
   const options: SearchOption[] = models.map((m) => {
-    const bits = [modelVision(providerId, m.id) && "vision", m.reasoning ? "reasoning" : "fast"].filter(Boolean);
+    const bits = [hasVision(providerId, m) && "vision", m.reasoning ? "reasoning" : "fast"].filter(Boolean);
     return { value: m.id, label: m.display_name, hint: bits.join(" · ") };
   });
+
+  // Warn only when we KNOW it can't see (false), not when capability is unknown.
+  const liveBlind = model ? hasVision(providerId, model) === false : false;
+  const hasVisionModel = !!settings?.visionModel;
 
   const changeModel = (id: string) => {
     const m = models.find((x) => x.id === id);
@@ -138,7 +184,33 @@ export function ModelsSettings() {
           placeholder={models.length ? "Select a model…" : "Add a key to load models…"}
           disabled={!models.length} emptyText="No models match" />
         <ModelBadges providerId={providerId} m={model} />
+        {liveBlind && (
+          <div className="mt-3 flex items-start gap-2 rounded-lg border border-arc/40 bg-arc-soft px-3 py-2.5 text-[12px] leading-relaxed text-foreground">
+            <AlertTriangle className="mt-0.5 size-4 shrink-0 text-arc" />
+            <span>
+              <b>{model?.display_name}</b> can’t see images — camera & screen won’t work with it.
+              {hasVisionModel ? " A vision model is set below, so frames route through that." : " Pick a vision-capable model, or set a dedicated vision model below."}
+            </span>
+          </div>
+        )}
       </Section>
+
+      <details className="group border-b border-border pb-7 last:border-0 last:pb-0">
+        <summary className="flex cursor-pointer list-none items-center justify-between gap-3 [&::-webkit-details-marker]:hidden">
+          <div>
+            <h2 className="flex items-center gap-1.5 text-[14px] font-semibold text-foreground">
+              <EyeOff className="size-3.5 text-muted-foreground" /> Vision model
+              <span className="rounded bg-surface px-1.5 py-0.5 text-[10.5px] font-normal text-muted-foreground">optional · advanced</span>
+            </h2>
+            <p className="mt-1 max-w-xl text-[12.5px] leading-relaxed text-muted-foreground">
+              Leave off and the live model sees for itself. Pick one to route camera/screen through a
+              different model — used <b className="text-foreground">only</b> for vision, even if the live model can already see.
+            </p>
+          </div>
+          <ChevronDown className="size-4 shrink-0 text-muted-foreground transition group-open:rotate-180" />
+        </summary>
+        <div className="mt-3.5"><VisionModelPicker /></div>
+      </details>
 
       <Section title="Reasoning effort"
         desc={<><b className="text-foreground">Auto</b> keeps the voice snappy (lowest the model supports). Raise it for deeper answers — but higher effort means a longer pause before it starts speaking.</>}>
@@ -147,7 +219,7 @@ export function ModelsSettings() {
             <button key={e} onClick={() => saveSetting.mutate({ liveEffort: e })}
               className={cn("rounded-md px-3.5 py-1.5 text-[12.5px] font-medium capitalize transition",
                 effort === e ? "bg-foreground text-background shadow-sm" : "text-muted-foreground hover:bg-foreground/[0.06] hover:text-foreground")}>
-              {e}
+              {e === "auto" ? "Auto ✦" : e}
             </button>
           ))}
         </div>

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -2,13 +2,16 @@ import type { Provider, ChatSummary, ChatMessage } from "@openlive/shared";
 
 export interface ModelInfo {
   id: string; display_name: string; created_at?: string;
-  contextWindow?: number; maxOutput?: number; reasoning?: boolean;
+  contextWindow?: number; maxOutput?: number; reasoning?: boolean; vision?: boolean;
   cost?: { input: number; output: number };
 }
 export interface AppSettings {
   liveModel?: string;
   liveProviderId?: string;
   liveEffort?: string;
+  /** Optional dedicated vision model (own provider) for when the live model can't see. */
+  visionProviderId?: string;
+  visionModel?: string;
 }
 
 async function j<T>(res: Response): Promise<T> {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -15,8 +15,8 @@ the wire.
 │  mic → VAD → STT → end-of-turn ─┐   /live WS   ┌─ LiveTurnRunner     │
 │  (Silero)(Whisper)(Smart-Turn)  ├── text ────▶ │   → model provider  │
 │                                 │   +frames    │   (BYO key)         │
-│  speaker ← TTS ← sentences ─────┘◀── reply ────┘   ↑ Anthropic /     │
-│           (Kokoro)                  (SSE text)      OpenAI / MiniMax  │
+│  speaker ← TTS ← sentences ─────┘◀── reply ────┘   ↑ any provider    │
+│           (Kokoro)                  (SSE text)      (BYO key)         │
 │    ▲ camera / screen frames ────────┘                               │
 └─────────────────────────────────────────────────────────────────────┘
 ```
@@ -50,10 +50,15 @@ download *and* the shader recompile (`models.worker.ts` warms shaders on load).
 ## The model turn (`services/agent`)
 
 `LiveSession` owns one WebSocket. `LiveTurnRunner` holds the growing `Message[]`
-and drives each turn through `streamProvider` (the provider-neutral adapter in
-`packages/harness` — Anthropic, OpenAI, and MiniMax, which speaks the Anthropic
-protocol). Reasoning is off by default for the snappiest voice; frames ride only
-the two most recent user turns for cost and latency.
+and drives each turn through `streamProvider` in `packages/harness`, where three
+wire adapters cover every provider: **Anthropic** (`/messages` — Claude + MiniMax),
+**OpenAI Responses** (`/responses` — OpenAI + Ollama), and **OpenAI Chat**
+(`/chat/completions` — Google, xAI, DeepSeek, Groq, Mistral, and the rest). A
+provider is just a registry row (id, protocol, base URL, key), so adding one is a
+few lines. Reasoning is off by default for the snappiest voice; frames ride only
+the two most recent user turns for cost and latency. When a separate vision model
+is configured, a text-only live model still sees — the vision model describes the
+frames and its description rides the turn.
 
 **Warm-up.** On session open the runner fires a tiny prefill (`warm()`) to heat the
 prompt cache and the connection, then the agent sends `{status:"ready"}` so the UI
@@ -96,7 +101,7 @@ on-demand camera/screen frame), `remember` (a fact that persists across calls),
 ## Packages
 
 ```
-packages/harness   model adapters (Anthropic / OpenAI / MiniMax), model listing, effort
+packages/harness   model adapters (Anthropic / OpenAI Responses / OpenAI Chat), live model listing, effort
 packages/shared    the /live wire protocol + shared types
 packages/db        JSON-file store: AES-256-GCM-encrypted keys, settings, conversations
 ```

--- a/packages/harness/src/catalog.ts
+++ b/packages/harness/src/catalog.ts
@@ -70,6 +70,7 @@ export async function getModels(providerId: string, catalogId?: string): Promise
         providerId,
         contextWindow: m.limit?.context ?? m.context_length,
         reasoning: !!m.reasoning,
+        vision: m.modalities?.input?.includes("image") || undefined,
       })
     }
   }

--- a/packages/harness/src/index.ts
+++ b/packages/harness/src/index.ts
@@ -1,6 +1,7 @@
 import type { ChatRequest, ProviderEvent, ProviderInfo } from "./types"
 import { streamAnthropic } from "./anthropic"
 import { streamOpenAIResponses } from "./openai-responses"
+import { streamOpenAIChat } from "./openai-chat"
 
 export * from "./types"
 export * from "./effort"
@@ -8,8 +9,8 @@ export * from "./catalog"
 export * from "./models"
 export * from "./registry"
 
-/** Dispatch a streaming chat request to the right wire adapter. Two adapters:
- *  Anthropic (Claude + MiniMax's Anthropic-compat endpoint) and OpenAI Responses. */
+/** Dispatch a streaming chat request to the right wire adapter: Anthropic
+ *  (/messages), OpenAI Responses (/responses), or OpenAI Chat (/chat/completions). */
 export function streamProvider(
   provider: ProviderInfo,
   apiKey: string | undefined,
@@ -18,5 +19,7 @@ export function streamProvider(
 ): AsyncGenerator<ProviderEvent> {
   if (provider.protocol === "anthropic")
     return streamAnthropic({ baseURL: provider.baseURL, apiKey, req, signal, quirks: provider.quirks })
+  if (provider.protocol === "openai-chat")
+    return streamOpenAIChat({ baseURL: provider.baseURL, apiKey, req, signal })
   return streamOpenAIResponses({ baseURL: provider.baseURL, apiKey, req, signal })
 }

--- a/packages/harness/src/models.ts
+++ b/packages/harness/src/models.ts
@@ -62,6 +62,11 @@ function enrich(l: LiveModel, meta: any, providerId: string): ModelInfo {
     contextWindow: meta?.limit?.context ?? l.raw?.context_length ?? l.raw?.inputTokenLimit,
     maxOutput: meta?.limit?.output ?? l.raw?.outputTokenLimit,
     reasoning: meta?.reasoning ?? isReasoningModel(l.id),
+    // Real image-input capability: models.dev modalities, else the provider's own
+    // payload (OpenRouter ships `architecture.input_modalities`). undefined = unknown.
+    vision:
+      meta?.modalities?.input?.includes("image") ??
+      (l.raw?.architecture?.input_modalities?.includes?.("image") || undefined),
     cost: costFrom(meta, l.raw),
     live: true,
   }

--- a/packages/harness/src/openai-chat.ts
+++ b/packages/harness/src/openai-chat.ts
@@ -1,0 +1,126 @@
+import type { ChatRequest, Message, ProviderEvent, ToolDef } from "./types"
+import { fetchWithRetry } from "./retry"
+import { sseLines } from "./sse"
+
+/** The OpenAI Chat Completions wire (`/chat/completions`) — the near-universal
+ *  dialect. Groq, Together, Fireworks, OpenRouter, DeepSeek, Mistral, xAI, and
+ *  most other hosted providers speak it (OpenAI's own Responses API and Ollama
+ *  are handled by the `openai` adapter instead). */
+
+function toChatMessages(messages: Message[]): unknown[] {
+  const out: Record<string, unknown>[] = []
+  for (const m of messages) {
+    if (m.role === "system") {
+      out.push({ role: "system", content: m.text })
+    } else if (m.role === "user") {
+      if (m.images?.length) {
+        const content: Record<string, unknown>[] = []
+        if (m.text) content.push({ type: "text", text: m.text })
+        for (const img of m.images)
+          content.push({ type: "image_url", image_url: { url: `data:${img.mime};base64,${img.data}` } })
+        out.push({ role: "user", content })
+      } else out.push({ role: "user", content: m.text })
+    } else if (m.role === "assistant") {
+      const msg: Record<string, unknown> = { role: "assistant", content: m.text ?? "" }
+      if (m.toolCalls?.length) {
+        msg.tool_calls = m.toolCalls.map((tc) => ({
+          id: tc.id,
+          type: "function",
+          function: { name: tc.name, arguments: tc.arguments || "{}" },
+        }))
+      }
+      out.push(msg)
+    } else if (m.role === "tool") {
+      // ponytail: the tool role is text-only across Chat Completions providers —
+      // tool-result images (computer-use screenshots) are dropped here. Use an
+      // `anthropic`/Responses provider if you need vision-in-tool-results.
+      out.push({ role: "tool", tool_call_id: m.callId, content: m.result })
+    }
+  }
+  return out
+}
+
+function toTools(tools: ToolDef[]): unknown[] {
+  return tools.map((t) => ({
+    type: "function",
+    function: { name: t.name, description: t.description, parameters: t.parameters },
+  }))
+}
+
+export async function* streamOpenAIChat(opts: {
+  baseURL: string
+  apiKey?: string
+  req: ChatRequest
+  signal: AbortSignal
+  headers?: Record<string, string>
+}): AsyncGenerator<ProviderEvent> {
+  const { baseURL, apiKey, req, signal } = opts
+  const body: Record<string, unknown> = {
+    model: req.model,
+    messages: toChatMessages(req.messages),
+    stream: true,
+    stream_options: { include_usage: true },
+  }
+  if (req.tools.length) body.tools = toTools(req.tools)
+  // Raw passthrough only. Most Chat Completions providers reject an unknown
+  // `reasoning_effort`, and reasoning models here are always-on (they emit
+  // reasoning_content regardless), so we don't send the mapped Effort.
+  if (req.reasoningEffort) body.reasoning_effort = req.reasoningEffort
+  if (req.maxTokens) body.max_tokens = req.maxTokens
+
+  const res = await fetchWithRetry(
+    `${baseURL.replace(/\/$/, "")}/chat/completions`,
+    {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        ...(apiKey ? { authorization: `Bearer ${apiKey}` } : {}),
+        ...opts.headers,
+      },
+      body: JSON.stringify(body),
+      signal,
+    },
+    signal,
+  )
+  if (!res.ok || !res.body) {
+    const text = await res.text().catch(() => "")
+    throw new Error(`HTTP ${res.status}: ${text.slice(0, 400) || res.statusText}`)
+  }
+
+  const seen = new Set<number>() // tool-call indexes we've already tool_start'ed
+  let stopReason = "stop"
+
+  for await (const line of sseLines(res.body)) {
+    if (!line.startsWith("data:")) continue
+    const payload = line.slice(5).trim()
+    if (!payload || payload === "[DONE]") break
+    let ev: any
+    try {
+      ev = JSON.parse(payload)
+    } catch {
+      continue
+    }
+    // Usage arrives on a trailing chunk (choices often empty) when include_usage is set.
+    if (ev.usage) yield { type: "usage", input: ev.usage.prompt_tokens ?? 0, output: ev.usage.completion_tokens ?? 0 }
+
+    const choice = ev.choices?.[0]
+    if (!choice) continue
+    const d = choice.delta
+    if (d?.content) yield { type: "text", delta: d.content }
+    // reasoning_content (DeepSeek), reasoning (OpenRouter/others)
+    const rc = d?.reasoning_content ?? d?.reasoning
+    if (rc) yield { type: "reasoning", delta: rc }
+    for (const tc of d?.tool_calls ?? []) {
+      const index = tc.index ?? 0
+      if (!seen.has(index)) {
+        seen.add(index)
+        yield { type: "tool_start", index, id: tc.id ?? `call_${index}`, name: tc.function?.name ?? "" }
+      }
+      if (tc.function?.arguments) yield { type: "tool_delta", index, argsDelta: tc.function.arguments }
+    }
+    if (choice.finish_reason) stopReason = choice.finish_reason
+  }
+
+  for (const index of seen) yield { type: "tool_stop", index }
+  yield { type: "done", stopReason }
+}

--- a/packages/harness/src/registry.ts
+++ b/packages/harness/src/registry.ts
@@ -40,6 +40,110 @@ export const BUILTIN_PROVIDERS: BuiltinProvider[] = [
     catalogId: "minimax",
     quirks: { noCacheControl: true, noThinking: true, bearerAuth: true },
   },
+  {
+    // Local Ollama. Speaks the OpenAI Responses API (/v1/responses, Ollama
+    // v0.13.3+), so the existing "openai" adapter works unchanged. Keyless — the
+    // OpenAI SDK requires a token but Ollama ignores it locally. Models come live
+    // from /v1/models (whatever you've `ollama pull`ed).
+    id: "ollama",
+    name: "Ollama (local)",
+    protocol: "openai",
+    baseURL: "http://localhost:11434/v1",
+    keyless: true,
+  },
+  {
+    // Ollama Cloud — same wire, hosted. Needs a real key (ollama.com/settings/keys),
+    // sent as Bearer by the openai adapter.
+    id: "ollama-cloud",
+    name: "Ollama Cloud",
+    protocol: "openai",
+    baseURL: "https://ollama.com/v1",
+    envKeys: ["OLLAMA_API_KEY"],
+  },
+  // --- Chat Completions providers (the universal /chat/completions dialect) ---
+  // All Bearer-auth, all list models live from /v1/models (except Perplexity,
+  // which has no /models — its snapshot below is the source of truth).
+  {
+    id: "groq",
+    name: "Groq",
+    protocol: "openai-chat",
+    baseURL: "https://api.groq.com/openai/v1",
+    envKeys: ["GROQ_API_KEY"],
+    catalogId: "groq",
+  },
+  {
+    id: "openrouter",
+    name: "OpenRouter",
+    protocol: "openai-chat",
+    baseURL: "https://openrouter.ai/api/v1",
+    envKeys: ["OPENROUTER_API_KEY"],
+    catalogId: "openrouter",
+  },
+  {
+    id: "deepseek",
+    name: "DeepSeek",
+    protocol: "openai-chat",
+    baseURL: "https://api.deepseek.com/v1",
+    envKeys: ["DEEPSEEK_API_KEY"],
+    catalogId: "deepseek",
+  },
+  {
+    id: "mistral",
+    name: "Mistral",
+    protocol: "openai-chat",
+    baseURL: "https://api.mistral.ai/v1",
+    envKeys: ["MISTRAL_API_KEY"],
+    catalogId: "mistral",
+  },
+  {
+    id: "xai",
+    name: "xAI (Grok)",
+    protocol: "openai-chat",
+    baseURL: "https://api.x.ai/v1",
+    envKeys: ["XAI_API_KEY"],
+    catalogId: "xai",
+  },
+  {
+    id: "google",
+    name: "Google Gemini",
+    protocol: "openai-chat",
+    baseURL: "https://generativelanguage.googleapis.com/v1beta/openai",
+    envKeys: ["GEMINI_API_KEY", "GOOGLE_API_KEY"],
+    catalogId: "google",
+  },
+  {
+    id: "together",
+    name: "Together",
+    protocol: "openai-chat",
+    baseURL: "https://api.together.xyz/v1",
+    envKeys: ["TOGETHER_API_KEY"],
+    catalogId: "togetherai",
+  },
+  {
+    id: "fireworks",
+    name: "Fireworks",
+    protocol: "openai-chat",
+    baseURL: "https://api.fireworks.ai/inference/v1",
+    envKeys: ["FIREWORKS_API_KEY"],
+    catalogId: "fireworks-ai",
+  },
+  {
+    id: "cerebras",
+    name: "Cerebras",
+    protocol: "openai-chat",
+    baseURL: "https://api.cerebras.ai/v1",
+    envKeys: ["CEREBRAS_API_KEY"],
+    catalogId: "cerebras",
+  },
+  {
+    // No /models endpoint — snapshot is the picker's only source.
+    id: "perplexity",
+    name: "Perplexity",
+    protocol: "openai-chat",
+    baseURL: "https://api.perplexity.ai",
+    envKeys: ["PERPLEXITY_API_KEY"],
+    catalogId: "perplexity",
+  },
 ]
 
 /** A sane default model id for a provider when the user hasn't picked one — the
@@ -57,4 +161,23 @@ export const MODEL_SNAPSHOT: Record<string, string[]> = {
   // MiniMax-M3 (1M ctx, vision) and M2.5 (vision) support images over the
   // Anthropic-compat endpoint; M2 is text-only.
   minimax: ["MiniMax-M3", "MiniMax-M2.5", "MiniMax-M2.5-highspeed"],
+  // ponytail: guesses so the picker has a default before /v1/models loads. Local
+  // depends on what you've pulled; cloud ids carry the `-cloud` suffix. Live fetch
+  // corrects both the moment the server/key is reachable.
+  ollama: ["llama3.2", "qwen3", "gemma3"],
+  "ollama-cloud": ["gpt-oss:120b-cloud", "qwen3-coder:480b-cloud", "deepseek-v3.1:671b-cloud"],
+  // ponytail: one sane default each so chat works pre-live-fetch; the picker
+  // fills the real list from /v1/models. Ids drift — treat as seeds, not truth.
+  // Verified current against models.dev on 2026-07-11; first entry is the
+  // zero-click default (prefer fast + vision for voice+camera).
+  groq: ["meta-llama/llama-4-scout-17b-16e-instruct", "llama-3.3-70b-versatile"],
+  openrouter: ["google/gemini-2.5-flash", "anthropic/claude-sonnet-4.5"],
+  deepseek: ["deepseek-v4-flash", "deepseek-v4-pro"], // -chat/-reasoner deprecated 2026-07-24
+  mistral: ["mistral-large-latest", "mistral-small-latest"],
+  xai: ["grok-4.5", "grok-4.3"], // grok-4 deprecated 2026-05-15
+  google: ["gemini-2.5-flash", "gemini-3.1-flash-lite", "gemini-2.5-pro"],
+  together: ["meta-llama/Llama-3.3-70B-Instruct-Turbo", "Qwen/Qwen2.5-72B-Instruct-Turbo"],
+  fireworks: ["accounts/fireworks/models/llama-v3p3-70b-instruct", "accounts/fireworks/models/deepseek-v3"],
+  cerebras: ["gemma-4-31b", "zai-glm-4.7", "gpt-oss-120b"],
+  perplexity: ["sonar", "sonar-pro", "sonar-reasoning"],
 }

--- a/packages/harness/src/types.ts
+++ b/packages/harness/src/types.ts
@@ -11,8 +11,10 @@ export const EFFORTS: readonly Effort[] = ["low", "medium", "high", "xhigh", "ma
  * `reasoning_effort` only accepts low/medium/high (xhigh/max collapse to high), while Anthropic and
  * Google take a thinking-token budget and honor all five. A non-reasoning model supports none.
  */
-export function allowedEfforts(protocol?: "openai" | "anthropic", reasoning = true): readonly Effort[] {
+export function allowedEfforts(protocol?: Protocol, reasoning = true): readonly Effort[] {
   if (!reasoning) return []
+  // Chat Completions providers are always-on-reasoning (no per-request effort knob).
+  if (protocol === "openai-chat") return []
   if (protocol === "openai") return ["low", "medium", "high"]
   return EFFORTS
 }
@@ -58,10 +60,12 @@ export interface ChatRequest {
   maxTokens?: number
 }
 
-/** Provider wire protocol — selects the adapter. Two adapters cover all three
- *  supported providers: Anthropic (Claude + MiniMax via its Anthropic-compat
- *  endpoint) and OpenAI (the Responses API). */
-export type Protocol = "openai" | "anthropic"
+/** Provider wire protocol — selects the adapter. Three adapters:
+ *  - `anthropic`   → /messages (Claude + MiniMax's Anthropic-compat endpoint)
+ *  - `openai`      → /responses (OpenAI Responses API + Ollama v0.13.3+)
+ *  - `openai-chat` → /chat/completions (the universal dialect: Groq, Together,
+ *                    Fireworks, OpenRouter, DeepSeek, Mistral, xAI, Cerebras, …) */
+export type Protocol = "openai" | "openai-chat" | "anthropic"
 
 /** Per-provider deviations from the canonical wire format of its protocol.
  *  MiniMax speaks the Anthropic protocol but doesn't accept `cache_control`
@@ -100,6 +104,8 @@ export interface ModelInfo {
   maxOutput?: number
   /** model exposes a reasoning/thinking channel */
   reasoning?: boolean
+  /** accepts image input (real capability from models.dev modalities / provider payload; undefined = unknown) */
+  vision?: boolean
   /** USD per 1M tokens, when known */
   cost?: { input: number; output: number }
   /** true when surfaced from the provider's own live endpoint (vs offline snapshot) */

--- a/services/agent/src/live/turn-runner.ts
+++ b/services/agent/src/live/turn-runner.ts
@@ -2,8 +2,26 @@ import { streamProvider, isReasoningModel, type Message, type Effort } from "@op
 import { buildTaktTools, type TaktTool, type Emit } from "../tools.js";
 import { collectTurn } from "../turn.js";
 import { buildLivePrompt } from "../prompt.js";
-import { resolveLive } from "../providers.js";
+import { resolveLive, resolveVision, type ResolvedLive } from "../providers.js";
 import { runWorker } from "./worker.js";
+
+type Frame = { data: string; mime: string; source?: "camera" | "screen" };
+
+/** Have the dedicated vision model look at the frames and report what's there, so
+ *  a text-only live model can still "see". One extra round-trip — only taken when
+ *  the user has configured a vision model. Returns "" on failure (caller falls
+ *  back to attaching the frames to the live model directly). */
+async function describeFrames(v: ResolvedLive, userText: string, frames: Frame[], sources: string, signal: AbortSignal): Promise<string> {
+  const messages: Message[] = [
+    { role: "system", text: `You are the eyes of a voice assistant. In 1-3 tight sentences, state exactly what is visible in the user's ${sources} right now — objects, on-screen text, layout, what the person is doing. No preamble, no "the image". If it's blank or unreadable, say so plainly.` },
+    { role: "user", text: userText ? `The user said: "${userText}". What's visible?` : "What's visible right now?", images: frames.map((f) => ({ data: f.data, mime: f.mime })) },
+  ];
+  const turn = await collectTurn(
+    streamProvider(v.provider, v.apiKey ?? undefined, { model: v.model, messages, tools: [], maxTokens: 512 }, signal),
+    () => {}, // its text is not spoken; we fold the description into the live turn
+  );
+  return turn.text.trim();
+}
 
 /** Parse streamed tool-arg JSON; tolerate an empty/blank string. */
 function safeParseArgs(s: string): any {
@@ -74,11 +92,25 @@ export class LiveTurnRunner {
     // model is picked, and if the provider genuinely can't take images it surfaces
     // a real error (never a faked "I can see"). Tell the model which source it is.
     let text = userText;
+    let imgs: { data: string; mime: string }[] | undefined;
     if (frames.length) {
       const sources = [...new Set(frames.map((f) => f.source ?? "camera"))].join(" and ");
-      text = `${userText}\n\n[You're viewing the user's ${sources} live right now — talk about what's actually there, not "the image". If you truly can't make it out or got no picture, say so plainly and never invent details.]`;
+      // If the user configured a separate vision model, let IT see and fold its
+      // description into this turn (so a text-only live model still works). Falls
+      // back to attaching the frames to the live model if the describe call fails.
+      const vision = resolveVision();
+      let described = "";
+      if (vision && vision.model !== model) {
+        try { described = await describeFrames(vision, userText, frames, sources, signal); } catch { /* fall back to frames */ }
+        if (signal.aborted) return;
+      }
+      if (described) {
+        text = `${userText}\n\n[A vision model is looking at the user's ${sources} live right now and reports: ${described}\nTalk about what's actually there, naturally — as what you're both looking at. Don't mention "the image" or that another model described it.]`;
+      } else {
+        text = `${userText}\n\n[You're viewing the user's ${sources} live right now — talk about what's actually there, not "the image". If you truly can't make it out or got no picture, say so plainly and never invent details.]`;
+        imgs = frames.map((f) => ({ data: f.data, mime: f.mime }));
+      }
     }
-    const imgs = frames.length ? frames.map((f) => ({ data: f.data, mime: f.mime })) : undefined;
     this.messages.push({ role: "user", text, images: imgs });
     // Keep frames only on the 2 most recent user turns (cost + latency).
     const withImgs = this.messages.filter((m) => m.role === "user" && m.images?.length);

--- a/services/agent/src/providers.ts
+++ b/services/agent/src/providers.ts
@@ -63,6 +63,19 @@ function liveProviderId(): string {
   return anyKeyed?.id ?? BUILTIN_PROVIDERS[0]!.id;
 }
 
+// Optional dedicated vision model (its own provider), used to SEE for a live
+// model that can't. Null unless the user configured one AND it's usable.
+export function resolveVision(): ResolvedLive | null {
+  const providerId = getSetting("visionProviderId");
+  const model = getSetting("visionModel");
+  if (!providerId || !model) return null;
+  const provider = providerInfo(providerId);
+  if (!provider) return null;
+  const apiKey = getProviderKey(providerId);
+  if (!apiKey && !provider.keyless) return null;
+  return { provider, model, apiKey };
+}
+
 export function resolveLive(): ResolvedLive {
   const providerId = liveProviderId();
   const provider = providerInfo(providerId) ?? BUILTIN_PROVIDERS[0]!;


### PR DESCRIPTION
New OpenAI Chat Completions adapter unlocks Google, xAI, DeepSeek, Mistral,
Groq, Cerebras, Together, Fireworks, OpenRouter, Perplexity, and Ollama
(local + cloud). Real vision metadata + capability warning, and an optional
dedicated vision model so text-only live models can still see. Docs + CHANGELOG.
