### PR TITLE
Add Telnyx as a model provider

### DIFF
--- a/packages/harness/src/registry.ts
+++ b/packages/harness/src/registry.ts
@@ -144,6 +144,18 @@ export const BUILTIN_PROVIDERS: BuiltinProvider[] = [
     envKeys: ["PERPLEXITY_API_KEY"],
     catalogId: "perplexity",
   },
+  {
+    // Telnyx Inference — OpenAI-compatible /chat/completions hosting open-source
+    // LLMs on Telnyx GPU infra. Lists models live at /v2/ai/models (OpenAI shape),
+    // so the openai-chat adapter works unchanged. Not in models.dev; the live
+    // fetch is the picker's primary source, snapshot below is the offline fallback.
+    id: "telnyx",
+    name: "Telnyx",
+    protocol: "openai-chat",
+    baseURL: "https://api.telnyx.com/v2/ai",
+    envKeys: ["TELNYX_API_KEY"],
+    catalogId: "telnyx",
+  },
 ]
 
 /** A sane default model id for a provider when the user hasn't picked one — the
@@ -180,4 +192,10 @@ export const MODEL_SNAPSHOT: Record<string, string[]> = {
   fireworks: ["accounts/fireworks/models/llama-v3p3-70b-instruct", "accounts/fireworks/models/deepseek-v3"],
   cerebras: ["gemma-4-31b", "zai-glm-4.7", "gpt-oss-120b"],
   perplexity: ["sonar", "sonar-pro", "sonar-reasoning"],
+  // ponytail: seeds so the picker has a default before /v2/ai/models loads; the
+  // live fetch overrides these the moment the key is set. Verified current
+  // 2026-07-11. First entry is the zero-click default (Kimi-K2.6: 1T/256K, fast
+  // + vision-capable, recommended for voice AI). GLM-5.2: 754B/1M context.
+  // MiniMax-M3-MXFP8: 428B/1M, cheapest at high intelligence.
+  telnyx: ["moonshotai/Kimi-K2.6", "zai-org/GLM-5.2", "MiniMaxAI/MiniMax-M3-MXFP8"],
 }


### PR DESCRIPTION
## What this changes

Adds **Telnyx** as a model provider, so OpenLive can talk to open-source LLMs hosted on [Telnyx Inference](https://telnyx.com/products/inference) GPU infrastructure.

Telnyx Inference is an OpenAI-compatible endpoint:
- Base URL: `https://api.telnyx.com/v2/ai`
- Auth: `Bearer $TELNYX_API_KEY`
- Lists models live at `/v2/ai/models` (OpenAI `{ object: "list", data: [...] }` shape)
- Speaks the Chat Completions wire (`/chat/completions`)

Because it speaks the universal `/chat/completions` dialect with Bearer auth, the existing `openai-chat` adapter works unchanged. This PR is a single `BUILTIN_PROVIDERS` entry plus a seed `MODEL_SNAPSHOT` — the same shape as the DeepSeek / Together / Fireworks / Perplexity entries added in v0.1.9.

### Seed models (verified current against the live `/v2/ai/models` endpoint, 2026-07-11)

| Model ID | Params | Context | Notes |
| --- | --- | --- | --- |
| `moonshotai/Kimi-K2.6` | 1.0T | 256K | Zero-click default. Recommended for voice AI (thinking disabled). Fast + vision-capable. |
| `zai-org/GLM-5.2` | 753.9B | 1M | Coding, reasoning, 1M context window. |
| `MiniMaxAI/MiniMax-M3-MXFP8` | 428B | 1M | Cheapest while maintaining high intelligence. |

These are seeds so the picker has a default before the live `/v2/ai/models` fetch loads; the fetch overrides them the moment the key is set. `catalogId: "telnyx"` is set for forward-compat if Telnyx ever lands in the models.dev catalog (today it isn't, and the code path falls back to the live fetch / snapshot gracefully).

## How I tested it

- `pnpm typecheck` passes clean across all workspace packages.
- Verified the live `/v2/ai/models` endpoint returns OpenAI-compatible shape (`{ object: "list", data: [...] }`) with 21 models, so the `fetchOpenAICompat` path in `packages/harness/src/models.ts` picks it up without adapter changes.

## Checklist
- [x] `pnpm typecheck` passes
- [x] One focused change, not several bundled together
- [ ] Screenshots added for UI changes _(N/A — no UI changes; the provider shows up in the existing Settings picker automatically)_

## Known limitations

The `vision` badge in the picker reads from models.dev `modalities.input` metadata or the OpenRouter `architecture.input_modalities` shape. Telnyx's `/v2/ai/models` returns vision capability as a boolean `is_vision_supported` field instead, so the badge may not light up for Telnyx models even when they support images. The models still work for voice + camera; only the picker badge is affected. I kept this PR scoped to provider registration only — vendor-specific metadata parsing is a separate concern.
