### PR TITLE
Fix the v0.2.0 mac universal release build

### DIFF
--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -42,6 +42,11 @@ mac:
     - target: zip
       arch: [universal]
   artifactName: ${productName}-${version}-mac.${ext}
+  # The agent bundle ships BOTH darwin sherpa-onnx platform packages (voice
+  # cloning; the addon picks by os.arch() at runtime), so those Mach-O files are
+  # identical across the two single-arch passes of the universal build. Declare
+  # them or electron-builder rejects the merge ("not covered by x64ArchFiles").
+  x64ArchFiles: "**/sherpa-onnx-darwin-*/**"
   hardenedRuntime: true
   gatekeeperAssess: false
   entitlements: build/entitlements.mac.plist


### PR DESCRIPTION
The 0.2.0 mac build failed at the universal merge: the agent bundle ships both darwin sherpa-onnx platform packages (voice cloning), whose Mach-O files are identical across the x64 and arm64 passes — electron-builder requires them declared in x64ArchFiles. Verified locally: the universal DMG builds clean with this change. Also includes the CI publish-never fix for the Windows smoke build.