### PR TITLE
Add Linux support (AppImage)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,3 +59,33 @@ jobs:
       # pull_request runs and fails the job after a successful build.
       - name: Build Windows installer (unsigned)
         run: pnpm --filter @openlive/desktop exec electron-builder --win --publish never
+
+  # Linux parity smoke test: prove the repo installs, typechecks, tests, and
+  # produces an unsigned AppImage on ubuntu-latest — same shape as the Windows job.
+  linux:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: pnpm/action-setup@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Typecheck
+        run: pnpm typecheck
+
+      - name: Test
+        run: pnpm test
+
+      - name: Pack web + agent
+        run: |
+          pnpm --filter @openlive/desktop pack:web
+          pnpm --filter @openlive/desktop pack:agent
+
+      - name: Build Linux AppImage (unsigned)
+        run: pnpm --filter @openlive/desktop exec electron-builder --linux --publish never

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,8 @@ jobs:
             name: mac
           - os: windows-latest
             name: win
+          - os: ubuntu-latest
+            name: linux
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v7
@@ -82,6 +84,12 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Build & publish (Linux — unsigned AppImage)
+        if: matrix.name == 'linux'
+        run: pnpm --filter @openlive/desktop exec electron-builder --linux --publish always
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   # Both platforms uploaded their assets to the draft release. Flip it to
   # published (and mark it "Latest") so it's downloadable. Runs only if every
   # build succeeded, so a half-built release never goes public.
@@ -114,6 +122,7 @@ jobs:
           | --- | --- |
           | **macOS** (Apple Silicon + Intel) | [\`${TAG}\` Mac (.dmg)](${BASE}/OpenLive-${TAG#v}-mac.dmg) |
           | **Windows** (64-bit) | [\`${TAG}\` Windows (.exe)](${BASE}/OpenLive-${TAG#v}-windows.exe) |
+          | **Linux** (64-bit) | [\`${TAG}\` Linux (.AppImage)](${BASE}/OpenLive-${TAG#v}-linux.AppImage) |
 
           On first launch, macOS may take a few seconds to verify the app. That's normal.
           "

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to OpenLive are recorded here. The newest version is on top.
 Releases before 0.1.9 predate this file — see the
 [GitHub releases](https://github.com/katipally/openlive/releases) for those.
 
+## [0.2.5] - 2026-07-18
+
+### Added
+- **Linux support.** OpenLive now ships a Linux build (unsigned `.AppImage`,
+  64-bit) alongside macOS and Windows — download, `chmod +x`, run. The release
+  and CI pipelines build and smoke-test all three platforms on their native
+  runners.
+
 ## [0.2.4] - 2026-07-17
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ Gemini Live, and OpenAI Realtime.
 [![Download for macOS](https://img.shields.io/badge/Download-macOS-0b0b0c?style=for-the-badge&logo=apple&logoColor=white)](https://github.com/katipally/openlive/releases/latest)
 &nbsp;
 [![Download for Windows](https://img.shields.io/badge/Download-Windows-0b0b0c?style=for-the-badge&logo=data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCIgZmlsbD0id2hpdGUiPjxwYXRoIGQ9Ik0zIDVsNy0xdjdIM3ptMCAxNGw3IDF2LTdIM3ptOC0xNXY4aDEwVjNsLTEwIDF6bTAgMTZsMTAgMVYxM0gxMXoiLz48L3N2Zz4=&logoColor=white)](https://github.com/katipally/openlive/releases/latest)
+&nbsp;
+[![Download for Linux](https://img.shields.io/badge/Download-Linux-0b0b0c?style=for-the-badge&logo=linux&logoColor=white)](https://github.com/katipally/openlive/releases/latest)
 
 </div>
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -8,8 +8,9 @@ CI typechecks every push and PR. A release is one tag, no manual version bump:
 git tag v0.2.0 && git push origin v0.2.0
 ```
 
-The tag drives the version. CI builds the macOS (universal, signed and notarized)
-and Windows installers, uploads them, and publishes the release with both downloads.
+The tag drives the version. CI builds the macOS (universal, signed and notarized),
+Windows, and Linux (unsigned AppImage) installers on their native runners, uploads
+them, and publishes the release with all three downloads.
 
 Mac signing runs when these repo secrets are set:
 `MAC_CSC_LINK`, `MAC_CSC_KEY_PASSWORD`, `APPLE_ID`, `APPLE_APP_SPECIFIC_PASSWORD`,

--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -90,3 +90,16 @@ nsis:
   perMachine: false
   allowToChangeInstallationDirectory: true
   createDesktopShortcut: true
+
+# ── Linux ─────────────────────────────────────────────────────────────────────
+# One AppImage (download → chmod +x → run) so users don't have to match a distro
+# package format. Unsigned, like every Linux AppImage. The linux-<arch> sherpa
+# package is shipped by pack-agent.cjs (its default branch). electron-builder
+# derives the icon set from the 1024×1024 build/icon.png automatically.
+linux:
+  target:
+    - target: AppImage
+      arch: [x64]
+  category: AudioVideo
+  artifactName: ${productName}-${version}-linux.${ext}
+  icon: build/icon.png

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -13,7 +13,8 @@
     "pack": "node scripts/pack-web.cjs && node scripts/pack-agent.cjs",
     "build": "pnpm run pack && electron-builder",
     "build:mac": "pnpm run pack && electron-builder --mac",
-    "build:win": "pnpm run pack && electron-builder --win"
+    "build:win": "pnpm run pack && electron-builder --win",
+    "build:linux": "pnpm run pack && electron-builder --linux"
   },
   "dependencies": {
     "electron-updater": "^6.8.9"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "desktop:dev": "cross-env AGENT_PORT=47823 WEB_PORT=47824 concurrently -k --kill-others -n web,agent,app -c cyan,magenta,green \"pnpm --filter @openlive/web dev\" \"pnpm --filter @openlive/agent dev\" \"pnpm --filter @openlive/desktop start:dev\"",
     "desktop:build": "pnpm --filter @openlive/desktop build",
     "desktop:build:mac": "pnpm --filter @openlive/desktop build:mac",
-    "desktop:build:win": "pnpm --filter @openlive/desktop build:win"
+    "desktop:build:win": "pnpm --filter @openlive/desktop build:win",
+    "desktop:build:linux": "pnpm --filter @openlive/desktop build:linux"
   },
   "devDependencies": {
     "concurrently": "^9.1.0",


### PR DESCRIPTION
Adds a Linux build alongside macOS and Windows, plus CI coverage.

## What
- **Linux AppImage** (64-bit, unsigned) — download → `chmod +x` → run.
- **release.yml**: `ubuntu-latest` added to the build matrix; Linux row in the download table.
- **ci.yml**: a Linux build smoke test (install → typecheck → test → build unsigned AppImage), mirroring the existing Windows job — so every PR proves an AppImage builds on Ubuntu.
- Scripts: `build:linux` / `desktop:build:linux`.
- README download badge, RELEASING note, CHANGELOG 0.2.5.

## Why it's low-risk
The only native dependency is `sherpa-onnx-node`. Its Linux prebuild (`sherpa-onnx-linux-x64@1.13.4`) already exists on npm, and `pack-agent.cjs` already had a `linux-<arch>` branch — the packing side was written Linux-aware from the start.

## Verification
- YAML valid, `pnpm typecheck` clean, `pnpm test` 77/77 pass locally.
- The real Linux build proof is the new **CI Linux job on ubuntu-latest** — a Mac can't produce a correct Linux binary (pack bundles the host-OS sherpa addon).

Once CI is green here, tag `v0.2.5` to cut the multi-platform release.
